### PR TITLE
Correction ancre menu création salarié + patch de plusieurs éléments

### DIFF
--- a/src/app/styles/colors.scss
+++ b/src/app/styles/colors.scss
@@ -4,7 +4,6 @@ $blue:#1E90D9;
 $pastelBlue:#DCE2FF;
 $pastelGrayBlue:#EAEAF4;
 $lightGray:#FAFBFF;
-$mediumGray: #ccc;
 $darkGray:#9FA4BE;
 $grayBackground:#F0F0F4;
 $white:#FFFFFF;

--- a/src/components/EmployeeBox/EmployeeBox.module.scss
+++ b/src/components/EmployeeBox/EmployeeBox.module.scss
@@ -7,8 +7,6 @@
     padding: 20px;
     border-radius: 20px;
     position: relative;
-    max-width: 350px;
-    margin: 0 auto;
     cursor: pointer;
 
     .employeeLetters {

--- a/src/components/layout/IconButton/IconButton.module.scss
+++ b/src/components/layout/IconButton/IconButton.module.scss
@@ -31,19 +31,19 @@
   }
 
   // Styles dynamiques
-  &.regular {
+  &.regular span {
     font-weight: var(--font-weight-regular);
   }
 
-  &.medium {
+  &.medium span {
     font-weight: var(--font-weight-medium);
   }
 
-  &.semibold {
+  &.semibold span {
     font-weight: var(--font-weight-semibold);
   }
 
-  &.bold {
+  &.bold span {
     font-weight: var(--font-weight-bold);
   }
 

--- a/src/components/layout/Sidebar/Sidebar.tsx
+++ b/src/components/layout/Sidebar/Sidebar.tsx
@@ -103,7 +103,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activePage, name, firstname, isLoadin
               <IconButton
                 startIcon={<HomeOutlinedIcon />}
                 text="Tableau de bord"
-                fontWeight="regular"
+                fontWeight="medium"
                 onClick={() => onMenuClick("dashboard")}
                 isDisabled={false}
                 variant={"ghost"}
@@ -118,7 +118,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activePage, name, firstname, isLoadin
               <IconButton
                 startIcon={<CalendarMonthOutlinedIcon />}
                 text="Planning"
-                fontWeight="bold"
+                fontWeight="medium"
                 onClick={() => onMenuClick("planning")}
                 isDisabled={false}
                 variant={"ghost"}
@@ -148,7 +148,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activePage, name, firstname, isLoadin
               <IconButton
                 startIcon={<ListAltIcon />}
                 text="Liste missions"
-                fontWeight="regular"
+                fontWeight="medium"
                 onClick={() => onMenuClick("missions")}
                 isDisabled={false}
                 variant={"ghost"}
@@ -166,7 +166,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activePage, name, firstname, isLoadin
               <IconButton
                 startIcon={<NotificationsNoneIcon />}
                 text="Notifications"
-                fontWeight="regular"
+                fontWeight="medium"
                 onClick={() => onMenuClick("notifications")}
                 isDisabled={false}
                 variant={"ghost"}
@@ -181,7 +181,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activePage, name, firstname, isLoadin
               <IconButton
                 startIcon={<PersonOutlineIcon />}
                 text="Compte"
-                fontWeight="regular"
+                fontWeight="medium"
                 onClick={() => onMenuClick("compte")}
                 isDisabled={false}
                 variant={"ghost"}
@@ -196,7 +196,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activePage, name, firstname, isLoadin
               <IconButton
                 startIcon={<LogoutIcon />}
                 text="Se déconnecter"
-                fontWeight="regular"
+                fontWeight="medium"
                 onClick={() => onMenuClick("logout")}
                 isDisabled={false}
                 variant={"ghost"}

--- a/src/pages/Employee/CreateEmployeePage/CreateEmployeePage.module.scss
+++ b/src/pages/Employee/CreateEmployeePage/CreateEmployeePage.module.scss
@@ -16,6 +16,11 @@
   max-height: calc(100% - 40px);
   gap: 30px;
 
+  @include mixinBreakpoints(xs) {
+    padding: 15px 20px;
+    gap: 20px;
+  }
+
   .menu {
     position: sticky;
     top: 20px;
@@ -28,7 +33,7 @@
     button {
       justify-content: flex-start;
 
-      @include mixinBreakpoints(xs) {
+      @include mixinBreakpoints(lg) {
         :global(.iconTextGlobal) {
           display: none;
         }
@@ -49,24 +54,33 @@
 
     .sectionTitle {
       font-size: 25px;
+      font-weight: var(--font-weight-medium);
     }
 
     .subSectionTitle {
       color: $darkGray;
       font-size: 15px;
       margin-bottom: 30px;
+      padding-bottom: 15px;
+      border-bottom: solid 1px $grayBackground;
     }
 
     .selectRole {
       margin-top: 25px;
       width: 50%;
+
+      @include mixinBreakpoints(xl) {
+        width: 100%;
+      }
     }
 
     .validateButtons {
       display: flex;
-      gap: 30px;
+      flex-wrap: wrap;
+      column-gap: 30px;
+      row-gap: 10px;
       margin-top: 50px;
-      justify-content: center;
+      justify-content: flex-end;
     }
   }
 
@@ -75,18 +89,18 @@
   }
 
   .formGrid {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 16px;
-  }
 
-  .input {
-    flex-basis: calc(50% - 8px);
-    min-width: 250px;
+    @include mixinBreakpoints(xl) {
+      grid-template-columns: 1fr;
+    }
   }
 
   .checkboxGroup {
     display: flex;
-    gap: 32px;
+    flex-wrap: wrap;
+    column-gap: 32px;
   }
 }

--- a/src/pages/Employee/CreateEmployeePage/CreateEmployeePage.module.scss
+++ b/src/pages/Employee/CreateEmployeePage/CreateEmployeePage.module.scss
@@ -3,19 +3,20 @@
 @use '../../../app/styles/mixins'as *;
 
 
-:has(.container) {
+:has(.createEmployeeContainer) {
   overflow-y: hidden;
 }
-.container {
+
+.createEmployeeContainer {
   display: flex;
   background-color: $white;
   padding: 20px 30px;
   border-radius: 8px;
   overflow-y: auto;
   max-height: calc(100% - 40px);
+  gap: 30px;
 
-  
-  .sidebar {
+  .menu {
     position: sticky;
     top: 20px;
     align-self: flex-start;
@@ -23,10 +24,10 @@
     display: flex;
     flex-direction: column;
     gap: 24px;
-  
+
     button {
       justify-content: flex-start;
-  
+
       @include mixinBreakpoints(xs) {
         :global(.iconTextGlobal) {
           display: none;
@@ -34,14 +35,12 @@
       }
     }
   }
-  
+
   .separator {
     width: 1px;
-    background-color: $mediumGray;
-    margin-right: 24px;
-    margin-left: 8px;
+    background-color: $grayBackground;
   }
-  
+
   .content {
     flex: 1;
     position: relative;
@@ -70,25 +69,24 @@
       justify-content: center;
     }
   }
-  
+
   .section {
     margin-bottom: 48px;
   }
-  
+
   .formGrid {
     display: flex;
     flex-wrap: wrap;
     gap: 16px;
   }
-  
+
   .input {
     flex-basis: calc(50% - 8px);
     min-width: 250px;
   }
-  
+
   .checkboxGroup {
     display: flex;
     gap: 32px;
   }
 }
-  

--- a/src/pages/Employee/CreateEmployeePage/CreateEmployeePage.tsx
+++ b/src/pages/Employee/CreateEmployeePage/CreateEmployeePage.tsx
@@ -383,10 +383,13 @@ const CreateEmployeePage: React.FC<createEmployeePageProps> = ({
 
         <div className={styles.validateButtons}>
           <IconButton
-            text='annuler'
+            text='Annuler'
             variant='outlined'
             isRounded
             startIcon={<CloseIcon/>}
+            color='red'
+            fontWeight='medium'
+            onClick={() => handleNavigation("salarie", "Salariés")}
           />
 
           <IconButton
@@ -394,6 +397,7 @@ const CreateEmployeePage: React.FC<createEmployeePageProps> = ({
             variant='filled'
             isRounded
             startIcon={<DoneIcon />}
+            fontWeight='medium'
             onClick={handleSubmit}
           />
         </div>

--- a/src/pages/Employee/CreateEmployeePage/CreateEmployeePage.tsx
+++ b/src/pages/Employee/CreateEmployeePage/CreateEmployeePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import {
   Checkbox,
   FormControlLabel,
@@ -7,9 +7,9 @@ import {
   Select,
   TextField,
 } from '@mui/material';
-import BusinessCenterIcon from '@mui/icons-material/BusinessCenter';
+import BusinessCenterOutlinedIcon from '@mui/icons-material/BusinessCenterOutlined';
 import CloseIcon from '@mui/icons-material/Close';
-import DescriptionIcon from '@mui/icons-material/Description';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import DoneIcon from '@mui/icons-material/Done';
 import InfoOutlineIcon from '@mui/icons-material/InfoOutline';
 import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone';
@@ -151,51 +151,78 @@ const CreateEmployeePage: React.FC<createEmployeePageProps> = ({
     submitEmployee();
   };
   
+  const infoRef = useRef<HTMLDivElement | null>(null);
+  const notifRef = useRef<HTMLDivElement | null>(null);
+  const docRef = useRef<HTMLDivElement | null>(null);
+  const paramRef = useRef<HTMLDivElement | null>(null);
+  
+  const scrollToSection = (ref: React.RefObject<HTMLDivElement>) => {
+    if (ref.current) {
+      ref.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
   return (
-    <div className={styles.container}>
-      <div className={styles.sidebar}>
+    <div className={styles.createEmployeeContainer}>
+      <div className={styles.menu}>
         <IconButton
           specialClass={styles.menuBtn}
           startIcon={<InfoOutlineIcon />}
           text="Informations générales"
           variant="ghost"
-          isRounded
+          isRounded={false}
           color={"darkGray"}
+          fontWeight={'medium'}
           isActive={activeButton === 'info'}
-          onClick={() => {setActiveButton('info')}}
+          onClick={() => {
+            setActiveButton('info');
+            scrollToSection(infoRef);
+          }}
         />
         <IconButton
           startIcon={<NotificationsNoneIcon />}
           text="Notifications"
           variant="ghost"
-          isRounded
+          isRounded={false}
           color={"darkGray"}
+          fontWeight={'medium'}
           isActive={activeButton === 'notif'}
-          onClick={() => {setActiveButton('notif')}}
+          onClick={() => {
+            setActiveButton('notif');
+            scrollToSection(notifRef);
+          }}
         />
         <IconButton
-          startIcon={<DescriptionIcon />}
+          startIcon={<DescriptionOutlinedIcon />}
           text="Documents"
           variant="ghost"
-          isRounded
+          isRounded={false}
           color={"darkGray"}
+          fontWeight={'medium'}
           isActive={activeButton === 'doc'}
-          onClick={() => {setActiveButton('doc')}}
+          onClick={() => {
+            setActiveButton('doc');
+            scrollToSection(docRef);
+          }}
         />
         <IconButton
-          startIcon={<BusinessCenterIcon />}
+          startIcon={<BusinessCenterOutlinedIcon />}
           text="Paramètres entreprise"
           variant="ghost"
-          isRounded
+          isRounded={false}
           color={"darkGray"}
+          fontWeight={'medium'}
           isActive={activeButton === 'param'}
-          onClick={() => {setActiveButton('param')}}
+          onClick={() => {
+            setActiveButton('param');
+            scrollToSection(paramRef);
+          }}
         />
       </div>
 
       <div className={styles.separator} />
       <div className={styles.content}>
-        <div className={styles.section}>
+        <div className={styles.section} ref={infoRef}>
           <p className={styles.sectionTitle}>Informations générales</p>
           <p className={styles.subSectionTitle}>Vous pouvez ajouter ou consulter vos documents administratifs</p>
 
@@ -288,7 +315,7 @@ const CreateEmployeePage: React.FC<createEmployeePageProps> = ({
           </div>
         </div>
 
-        <div className={styles.section}>
+        <div className={styles.section} ref={notifRef}>
           <p className={styles.sectionTitle}>Notifications</p>
           <p className={styles.subSectionTitle}>Vous pouvez modifier préférences en termes de notifications</p>
           <div className={styles.checkboxGroup}>
@@ -313,13 +340,13 @@ const CreateEmployeePage: React.FC<createEmployeePageProps> = ({
           </div>
         </div>
 
-        <div className={styles.section}>
+        <div className={styles.section} ref={docRef}>
           <p className={styles.sectionTitle}>Documents</p>
           <p className={styles.subSectionTitle}>Vous pouvez ajouter ou consulter vos documents administratifs</p>               
           <p>Oups, la fonctionnalité n'est pas encore créé.</p>
         </div>
 
-        <div className={styles.section}>
+        <div className={styles.section} ref={paramRef}>
           <p className={styles.sectionTitle}>Paramètres de l'entreprise</p>
           <p className={styles.subSectionTitle}>Vous pouvez modifier préférences en termes de notifications</p>
           <div className={styles.checkboxGroup}>

--- a/src/pages/EmployeesPage/EmployeesPage.module.scss
+++ b/src/pages/EmployeesPage/EmployeesPage.module.scss
@@ -21,17 +21,44 @@
     }
 }
 
-.addButton {
+.addButtonContainer {
     position: fixed;
+    display: flex;
+    align-items: center;
+    gap: 20px;
     bottom: 35px;
     right: 35px;
-    border: none;
-    border-radius: 50%;
-    width: 70px;
-    height: 70px;
-    font-size: 35px;
-    background-color: $blue;
-    color: $white;
-    cursor: pointer;
-    box-shadow: 5px 5px 25px 16px rgba($blue, 0.3);
+
+    .blurEffect {
+        position: absolute;
+        width: 300px;
+        height: 150px;
+        right: 0;
+        bottom: 0;
+        transform: translate(35%, 35%);
+        border-radius: 50%;
+        background: radial-gradient(circle, $blue 0%, rgba(217, 217, 217, 0) 70%);
+        filter: blur(50px);
+        z-index: 0;
+    }
+
+    .addButtonTexte {
+        z-index: 1;
+        padding: 10px 15px;
+        background-color: $white;
+        border-radius: 8px;
+        font-weight: var(--font-weight-medium);
+    }
+
+    .addButton {
+        z-index: 1;
+        border: none;
+        border-radius: 50%;
+        width: 70px;
+        height: 70px;
+        font-size: 35px;
+        background-color: $blue;
+        color: $white;
+        cursor: pointer;
+    }
 }

--- a/src/pages/EmployeesPage/EmployeesPage.module.scss
+++ b/src/pages/EmployeesPage/EmployeesPage.module.scss
@@ -4,16 +4,16 @@
 
 .listEmployeeContainer {
     display: grid;
-    grid-template-columns: repeat(1, 80%);
-    grid-column-gap: 5%;
-    grid-row-gap: 20px;
+    grid-template-columns: 1fr;
+    grid-column-gap: 40px;
+    grid-row-gap: 40px;
 
     @include mixinStart(lg) {
         grid-template-columns: repeat(2, 1fr);
     }
 
     @include mixinStart(xxl) {
-        grid-template-columns: repeat(3, 30%);
+        grid-template-columns: repeat(3, 1fr);
     }
 
     .employe_container {

--- a/src/pages/EmployeesPage/EmployeesPage.tsx
+++ b/src/pages/EmployeesPage/EmployeesPage.tsx
@@ -42,7 +42,11 @@ const EmployeesPage: React.FC<EmployeesPageProps> = ({
             <ul className={styles.listEmployeeContainer}>
                 {employeeBoxes}
             </ul>
-            <button className={styles.addButton} onClick={() => handleNavigation('salarieCreation', 'salarieCreation')}>+</button>
+            <div className={styles.addButtonContainer}>
+                <div className={styles.blurEffect}></div>
+                <p className={styles.addButtonTexte}>Ajout d'un employé</p>
+               <button className={styles.addButton} onClick={() => handleNavigation('salarieCreation', 'salarieCreation')}>+</button> 
+            </div>
         </>
     );
 };

--- a/src/pages/EmployeesPage/FilterEmployees/FilterEmployees.module.scss
+++ b/src/pages/EmployeesPage/FilterEmployees/FilterEmployees.module.scss
@@ -65,7 +65,7 @@
   @include mixinBreakpoints(sm) {
     flex-direction: column;
     flex-wrap: wrap;
-    height: 100%;
+    height: auto;
     gap: 10px;
 
     .filterTab {


### PR DESCRIPTION
Cette branche fix le menu ancre de création de salarié

elle corrige aussi
- responsive formulaire
- btn annuler reviens sur la page salarié
- ajout du texte "Ajout d'un salarié" fidèle a la maquette
- style formulaire
- J'ai changer nom de classe car il faudrait avoir des noms plus explicatifs surtout pour le parent, container c'est trop courant
- la weight qui était pas prise sur les iconButton, j'en ai profiter pour corriger sur la sidebar
- changement icon en outlined 
- correction du filtre en responsive
- responsive liste employés
- box employé responsive 